### PR TITLE
handle events that span multiple packets

### DIFF
--- a/src/main/java/com/google/code/or/io/impl/XInputStreamImpl.java
+++ b/src/main/java/com/google/code/or/io/impl/XInputStreamImpl.java
@@ -36,11 +36,12 @@ public class XInputStreamImpl extends InputStream implements XInputStream {
 	//
 	private int head = 0;
 	private int tail = 0;
-	private int readCount = 0;
-	private int readLimit = 0;
 	private final byte[] buffer;
 	private final InputStream is;
-	
+
+	protected int readCount = 0;
+	protected int readLimit = 0;
+
 
 	/**
 	 * 


### PR DESCRIPTION
when a row event happens that's greater than the max-packet-size
(2**24 - 1), it looks like:

[size, sequence]
16mb of data
[size, sequence]
data, continued...

handling this in the transport stream allows these packets to be properly processed.

@zendesk/rules by request.
