### PR TITLE
fix checksum overrun

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.zendesk</groupId>
   <artifactId>open-replicator</artifactId>
-  <version>1.2.3</version>
+  <version>1.3.0-RC1</version>
   <packaging>jar</packaging>
 
   <name>open-replicator</name>

--- a/src/main/java/com/google/code/or/net/impl/EventInputStream.java
+++ b/src/main/java/com/google/code/or/net/impl/EventInputStream.java
@@ -84,7 +84,7 @@ public class EventInputStream extends XInputStreamImpl implements XInputStream {
 		// Ensure the packet boundary
 		if(this.available() != 0) {
 			throw new RuntimeException("assertion failed!  We left " + this.available() +
-					"unconsumed bytes in the buffer for event: " + header);
+					" unconsumed bytes in the buffer for event: " + header);
 		}
 
 		if ( isChecksumEnabled() && header.getEventType() != MySQLConstants.FORMAT_DESCRIPTION_EVENT) {

--- a/src/main/java/com/google/code/or/net/impl/EventInputStream.java
+++ b/src/main/java/com/google/code/or/net/impl/EventInputStream.java
@@ -57,7 +57,7 @@ public class EventInputStream extends XInputStreamImpl implements XInputStream {
 		// setup the total event length; this is different than setReadLimit(),
 		// as setReadLimit refers to *packet* length.
 		long eventLimit = header.getEventLength() - 13;
-		if ( isChecksumEnabled() )
+		if ( isChecksumEnabled() && header.getEventType() != MySQLConstants.FORMAT_DESCRIPTION_EVENT )
 			eventLimit -= 4;
 
 		// TODO fixme re: int overflow


### PR DESCRIPTION
when we rotate to a new binlog file with checksums turned on we are crashing.  

@vanchi-zendesk @zendesk/rules 
