### PR TITLE
Better error for old style password auth

### DIFF
--- a/src/main/java/com/google/code/or/net/impl/AuthenticatorImpl.java
+++ b/src/main/java/com/google/code/or/net/impl/AuthenticatorImpl.java
@@ -30,6 +30,7 @@ import com.google.code.or.net.Transport;
 import com.google.code.or.net.TransportContext;
 import com.google.code.or.net.TransportException;
 import com.google.code.or.net.impl.packet.ErrorPacket;
+import com.google.code.or.net.impl.packet.EOFPacket;
 import com.google.code.or.net.impl.packet.OKPacket;
 import com.google.code.or.net.impl.packet.RawPacket;
 
@@ -86,6 +87,9 @@ public class AuthenticatorImpl implements Transport.Authenticator {
 			final ErrorPacket error = ErrorPacket.valueOf(response);
 			LOGGER.info("login failed, user: {}, error: {}", this.user, error);
 			throw new TransportException(error);
+		} else if(response.getPacketBody()[0] == EOFPacket.PACKET_MARKER) {
+			LOGGER.info("Old style password authentication is not supported, upgrade user {} to a new style password or specify a different user", this.user);
+			throw new RuntimeException("Old style password authentication not supported");
 		} else if(response.getPacketBody()[0] == OKPacket.PACKET_MARKER) {
 			final OKPacket ok = OKPacket.valueOf(response);
 			LOGGER.info("login successfully, user: {}, detail: {}", this.user, ok);


### PR DESCRIPTION
 I was stumped for a while on this error when trying to use open-replicator (via maxwell)

``` java
[main] INFO com.google.code.or.net.impl.TransportImpl - connecting to host: XX.XX.XXX.XXX, port: 3306
[main] INFO com.google.code.or.net.impl.TransportImpl - connected to host: XX.XX.XXX.XXX, port: 3306, context:               AbstractTransport.Context[threadId=3,scramble=XXX,protocolVersion=10,serverHost=XX.XX.XXX.XXX,              serverPort=3306,serverStatus=2,serverCollation=192,serverVersion=5.1.59-log,serverCapabilities=63487]
[main] INFO com.google.code.or.net.impl.AuthenticatorImpl - start to login, user: maxwell, host: XX.XX.XXX.XXX, port:        3306
[main] WARN com.google.code.or.net.impl.AuthenticatorImpl - login failed, unknown packet: 
Exception in thread "main" java.lang.RuntimeException: assertion failed, invalid packet: RawPacket[length=1,sequence=2]
    at com.google.code.or.net.impl.AuthenticatorImpl.login(AuthenticatorImpl.java:98)
    at com.google.code.or.net.impl.TransportImpl.connect(TransportImpl.java:105)
    at com.google.code.or.OpenReplicator.start(OpenReplicator.java:97)
    at Test.main(test.java:41)
```

It turns out my server was using old style passwords and `open-replicator` panicked when it received an unexpected packet requesting their use. MySQL sends an EOF packet to request a switch to old style auth

https://dev.mysql.com/doc/internals/en/connection-phase-packets.html#packet-Protocol::OldAuthSwitchRequest

the code changes just detect that and produce a friendlier error. Might save someone else from my headache of figuring it out.    
