### PR TITLE
fix toBigEndian method

### DIFF
--- a/src/main/java/com/google/code/or/common/util/CodecUtils.java
+++ b/src/main/java/com/google/code/or/common/util/CodecUtils.java
@@ -32,7 +32,7 @@ public final class CodecUtils {
 	 *
 	 */
 	public static byte[] toBigEndian(byte[] value) {
-		for(int i = 0, length = value.length >> 2; i <= length; i++) {
+		for(int i = 0, length = value.length >> 1; i < length; i++) {
 			final int j = value.length - 1 - i;
 			final byte t = value[i];
 			value[i] = value[j];


### PR DESCRIPTION
for 8 byte values, the previous method would iterate 3 times ( i = 0 ; i <= 2; i++) instead of 4, leading to incorrect values.

note that this function has never been actually safe for >8 byte values.

still TODO: a decent test suite for open-replicator.  I am, however, exercising these paths in maxwell just fine.

@zendesk/rules 
