### PR TITLE
Fixes around filtered out FORMAT_DESCRIPTION_EVENT events

### DIFF
--- a/src/test/java/com/google/code/or/OpenParserTest.java
+++ b/src/test/java/com/google/code/or/OpenParserTest.java
@@ -67,8 +67,11 @@ public class OpenParserTest {
 	@Test
 	public void TestParserWithoutFormatDescriptionListener() throws Exception {
 		OpenParser op = getOpenParser(fiveSixServer, "master.000001", 120L);
-		FileBasedBinlogParser bp = (FileBasedBinlogParser) op.getBinlogParser();
+
+		FileBasedBinlogParser bp = op.getDefaultBinlogParser();
 		bp.unregisterEventParser(MySQLConstants.FORMAT_DESCRIPTION_EVENT);
+		op.setBinlogParser(bp);
+
 		TestParserWithChecksums(op);
 	}
 }

--- a/src/test/java/com/google/code/or/OpenParserTest.java
+++ b/src/test/java/com/google/code/or/OpenParserTest.java
@@ -1,36 +1,43 @@
 package com.google.code.or;
 
+import com.google.code.or.binlog.*;
+import com.google.code.or.binlog.impl.FileBasedBinlogParser;
 import com.google.code.or.binlog.impl.event.WriteRowsEventV2;
+import com.google.code.or.common.util.MySQLConstants;
 import org.junit.BeforeClass;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.junit.Test;
 
-import com.google.code.or.binlog.BinlogEventListener;
-import com.google.code.or.binlog.BinlogEventV4;
-
 public class OpenParserTest {
-	//
-	private static final Logger LOGGER = LoggerFactory.getLogger(OpenParserTest.class);
+	static OnetimeServer fiveSixServer = null;
 
-	static int eventCount;
-
-	private void TestParserWithChecksums(long offset) throws Exception {
-		OnetimeServer fiveSixServer = new OnetimeServer("5.6");
+	@BeforeClass
+	public static void setupOnetimeServer() throws Exception {
+		fiveSixServer = new OnetimeServer("5.6");
 
 		fiveSixServer.boot();
 		fiveSixServer.execute("create database foo");
 		fiveSixServer.execute("create table foo.bar ( id int(10) primary key )");
 		fiveSixServer.execute("insert into foo.bar set id = 1");
 		fiveSixServer.execute("insert into foo.bar set id = 2");
+	}
+	//
+	private static final Logger LOGGER = LoggerFactory.getLogger(OpenParserTest.class);
 
+	static int eventCount;
+
+	private OpenParser getOpenParser(OnetimeServer server, String fileName, long offset) {
 		final OpenParser op = new OpenParser();
 
 		op.setStartPosition(offset);
-		op.setBinlogFileName("master.000001");
-		op.setBinlogFilePath(fiveSixServer.mysqlPath);
+		op.setBinlogFileName(fileName);
+		op.setBinlogFilePath(server.mysqlPath);
+		return op;
+	}
 
+	private void TestParserWithChecksums(OpenParser op) throws Exception {
 		eventCount = 0;
 		op.setBinlogEventListener(new BinlogEventListener() {
 			public void onEvents(BinlogEventV4 event) {
@@ -47,11 +54,21 @@ public class OpenParserTest {
 
 	@Test
 	public void TestParserWithChecksumsAtStart() throws Exception {
-		TestParserWithChecksums(4);
+		OpenParser op = getOpenParser(fiveSixServer, "master.000001", 4L);
+		TestParserWithChecksums(op);
 	}
 
 	@Test
 	public void TestParserWithChecksumsAtOffset() throws Exception {
-		TestParserWithChecksums(120);
+		OpenParser op = getOpenParser(fiveSixServer, "master.000001", 120L);
+		TestParserWithChecksums(op);
+	}
+
+	@Test
+	public void TestParserWithoutFormatDescriptionListener() throws Exception {
+		OpenParser op = getOpenParser(fiveSixServer, "master.000001", 120L);
+		FileBasedBinlogParser bp = (FileBasedBinlogParser) op.getBinlogParser();
+		bp.unregisterEventParser(MySQLConstants.FORMAT_DESCRIPTION_EVENT);
+		TestParserWithChecksums(op);
 	}
 }

--- a/src/test/java/com/google/code/or/OpenReplicatorTest.java
+++ b/src/test/java/com/google/code/or/OpenReplicatorTest.java
@@ -4,44 +4,87 @@ import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.util.concurrent.TimeUnit;
 
+import com.google.code.or.binlog.*;
+import com.google.code.or.binlog.impl.ReplicationBasedBinlogParser;
+import com.google.code.or.binlog.impl.event.WriteRowsEventV2;
+import com.google.code.or.common.util.MySQLConstants;
+import com.google.code.or.net.Transport;
+import org.junit.BeforeClass;
+import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.code.or.binlog.BinlogEventListener;
-import com.google.code.or.binlog.BinlogEventV4;
-
 public class OpenReplicatorTest {
-	//
 	private static final Logger LOGGER = LoggerFactory.getLogger(OpenReplicatorTest.class);
 
-	/**
-	 *
-	 */
-	public static void main(String args[]) throws Exception {
-		//
+	static OnetimeServer fiveSixServer = null;
+
+	@BeforeClass
+	public static void setupOnetimeServer() throws Exception {
+		fiveSixServer = new OnetimeServer("5.6");
+
+		fiveSixServer.boot();
+		fiveSixServer.execute("GRANT REPLICATION CLIENT, REPLICATION SLAVE on *.* to 'ortest'@'localhost' IDENTIFIED BY 'ortest'");
+		fiveSixServer.execute("create database foo");
+		fiveSixServer.execute("create table foo.bar ( id int(10) primary key )");
+		fiveSixServer.execute("insert into foo.bar set id = 1");
+		fiveSixServer.execute("insert into foo.bar set id = 2");
+	}
+	//
+
+	static int eventCount;
+	private OpenReplicator getOpenReplicator(OnetimeServer server, String fileName, long offset) {
 		final OpenReplicator or = new OpenReplicator();
-		or.setUser("nextop");
-		or.setPassword("nextop");
-		or.setHost("192.168.1.216");
-		or.setPort(3306);
-		or.setServerId(6789);
-		or.setBinlogPosition(120);
-		or.setBinlogFileName("mysql-bin.000003");
+
+		or.setHost("127.0.0.1");
+		or.setPort(server.getPort());
+		or.setUser("ortest");
+		or.setPassword("ortest");
+
+		or.setBinlogPosition(offset);
+		or.setBinlogFileName(fileName);
+		return or;
+	}
+
+	private void TestReplicator(OpenReplicator or) throws Exception {
+		eventCount = 0;
 		or.setBinlogEventListener(new BinlogEventListener() {
-		    public void onEvents(BinlogEventV4 event) {
-		    	LOGGER.info("{}", event);
-		    }
+			public void onEvents(BinlogEventV4 event) {
+				if (event instanceof WriteRowsEventV2) {
+					eventCount++;
+				}
+			}
 		});
 		or.start();
+		Thread.sleep(1000);
 
-		//
-		LOGGER.info("press 'q' to stop");
-		final BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
-		for(String line = br.readLine(); line != null; line = br.readLine()) {
-		    if(line.equals("q")) {
-		        or.stop(Long.MAX_VALUE, TimeUnit.MILLISECONDS);
-		        break;
-		    }
-		}
+		assert(eventCount == 2);
+	}
+
+	@Test
+	public void TestNormalReplicator() throws Exception {
+		TestReplicator(getOpenReplicator(fiveSixServer, "master.000001", 4L));
+	}
+
+	@Test
+	public void TestParserWithoutFormatDescriptionListener() throws Exception {
+		OpenReplicator or = getOpenReplicator(fiveSixServer, "master.000001", 120L);
+
+		Transport transport = or.getDefaultTransport();
+		transport.connect("localhost", fiveSixServer.getPort());
+		or.setTransport(transport);
+
+		ReplicationBasedBinlogParser bp = or.getDefaultBinlogParser();
+		bp.setTransport(transport);
+
+		bp.setEventFilter(new BinlogEventFilter() {
+			public boolean accepts(BinlogEventV4Header header, BinlogParserContext context) {
+				return header.getEventType() != MySQLConstants.FORMAT_DESCRIPTION_EVENT;
+			}
+		});
+
+		or.setBinlogParser(bp);
+
+		TestReplicator(or);
 	}
 }


### PR DESCRIPTION
I noticed that the exodus consumer was receiving FORMAT_DESCRIPTION_EVENT events that it didn't want to receive.  I dug deeper and noticed a whole slew of problems around our handling of formation-description in combination with event filters.  

@zendesk/rules 
