### PR TITLE
A row's 'null columns' bitfield size is nUsedColumns

### DIFF
--- a/src/main/java/com/google/code/or/binlog/impl/parser/AbstractRowEventParser.java
+++ b/src/main/java/com/google/code/or/binlog/impl/parser/AbstractRowEventParser.java
@@ -88,8 +88,8 @@ public abstract class AbstractRowEventParser extends AbstractBinlogEventParser {
 		int unusedColumnCount = 0;
 		final byte[] types = tme.getColumnTypes();
 		final Metadata metadata = tme.getColumnMetadata();
-		final BitColumn nullColumns = is.readBit(types.length);
-		final List<Column> columns = new ArrayList<Column>(types.length);
+		final BitColumn nullColumns = is.readBit(usedColumns.getSetBitCount());
+		final List<Column> columns = new ArrayList<Column>(usedColumns.getSetBitCount());
 		for(int i = 0; i < types.length; ++i) {
 			//
 			int length = 0;

--- a/src/main/java/com/google/code/or/binlog/impl/parser/AbstractRowEventParser.java
+++ b/src/main/java/com/google/code/or/binlog/impl/parser/AbstractRowEventParser.java
@@ -88,8 +88,9 @@ public abstract class AbstractRowEventParser extends AbstractBinlogEventParser {
 		int unusedColumnCount = 0;
 		final byte[] types = tme.getColumnTypes();
 		final Metadata metadata = tme.getColumnMetadata();
-		final BitColumn nullColumns = is.readBit(usedColumns.getSetBitCount());
-		final List<Column> columns = new ArrayList<Column>(usedColumns.getSetBitCount());
+		final int nColumnsUsed = usedColumns.getSetBitCount();
+		final BitColumn nullColumns = is.readBit(nColumnsUsed);
+		final List<Column> columns = new ArrayList<Column>(nColumnsUsed);
 		for(int i = 0; i < types.length; ++i) {
 			//
 			int length = 0;

--- a/src/main/java/com/google/code/or/common/glossary/column/BitColumn.java
+++ b/src/main/java/com/google/code/or/common/glossary/column/BitColumn.java
@@ -60,6 +60,15 @@ public final class BitColumn implements Column {
 		return this.length;
 	}
 
+	public int getSetBitCount() {
+		int count = 0;
+		for ( int i = 0 ; i < this.length ; i++ ) {
+			if ( get(i) )
+				count++;
+		}
+		return count;
+	}
+
 	public byte[] getValue() {
 		return this.value;
 	}


### PR DESCRIPTION
From https://dev.mysql.com/doc/internals/en/rows-event.html: nul-bitmap,
length (bits set in 'columns-present-bitmap1'+7)/8.  So if we had a
MINIMAL row format row with > 8 columns, and we encountered a row with
fewer 8 columns, boom.

@zendesk/rules 
