### PR TITLE
support GIS extension columns

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,11 @@
       <version>1.7.5</version>
     </dependency>
     <dependency>
+      <groupId>com.vividsolutions</groupId>
+      <artifactId>jts</artifactId>
+      <version>1.13</version>
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>
       <version>1.7.5</version>

--- a/src/main/java/com/google/code/or/binlog/impl/parser/AbstractRowEventParser.java
+++ b/src/main/java/com/google/code/or/binlog/impl/parser/AbstractRowEventParser.java
@@ -144,7 +144,7 @@ public abstract class AbstractRowEventParser extends AbstractBinlogEventParser {
 					final Geometry g = reader.read(is.readBytes(geomLength - 4));
 					columns.add(GeometryColumn.valueOf(g));
 				} catch ( ParseException e ) {
-					throw new RuntimeException("Could not parse geometry: ", e);
+					throw new RuntimeException("Could not parse geometry, unknown column was " + _unknown, e);
 				}
 
 				break;

--- a/src/main/java/com/google/code/or/common/glossary/Metadata.java
+++ b/src/main/java/com/google/code/or/common/glossary/Metadata.java
@@ -81,6 +81,7 @@ public final class Metadata implements Serializable {
             case MySQLConstants.TYPE_BLOB:
             case MySQLConstants.TYPE_MEDIUM_BLOB:
             case MySQLConstants.TYPE_LONG_BLOB:
+            case MySQLConstants.TYPE_GEOMETRY:
             	metadata[i] = d.readInt(1);
             	break;
             case MySQLConstants.TYPE_BIT:

--- a/src/main/java/com/google/code/or/common/glossary/column/GeometryColumn.java
+++ b/src/main/java/com/google/code/or/common/glossary/column/GeometryColumn.java
@@ -1,0 +1,21 @@
+package com.google.code.or.common.glossary.column;
+
+import com.google.code.or.common.glossary.Column;
+import com.vividsolutions.jts.geom.Geometry;
+
+public class GeometryColumn implements Column {
+    private Geometry geometry;
+
+    public GeometryColumn(Geometry g) {
+        this.geometry  = g;
+    }
+
+    public Geometry getValue() {
+        return this.geometry;
+    }
+
+    public static GeometryColumn valueOf(Geometry g) {
+        return new GeometryColumn(g);
+    }
+}
+

--- a/src/main/java/com/google/code/or/common/glossary/column/NullColumn.java
+++ b/src/main/java/com/google/code/or/common/glossary/column/NullColumn.java
@@ -27,7 +27,7 @@ public final class NullColumn implements Column {
 	private static final long serialVersionUID = 3300119160243172731L;
 
 	//
-	private static final NullColumn[] CACHE = new NullColumn[255];
+	private static final NullColumn[] CACHE = new NullColumn[256];
 	static {
 		for(int i = 0; i < CACHE.length; i++) {
 			CACHE[i] = new NullColumn(i);


### PR DESCRIPTION
All geometry columns are stored in the binlog as as single "TYPE_GEOMETRY", which is just a BLOB column with a different type.  Inside the blob is the "WKB" (well-known-binary) format, which we parse
with the 'jts' library.  Surprisingly simple.

@zendesk/rules 
