### PR TITLE
implement server heartbeats

### DIFF
--- a/src/main/java/com/google/code/or/OpenReplicator.java
+++ b/src/main/java/com/google/code/or/OpenReplicator.java
@@ -298,8 +298,8 @@ public class OpenReplicator {
 		return binlogParser.getHeartbeatCount();
 	}
 
-	public Long millisSinceLastHeartbeat() {
-		return binlogParser.millisSinceLastHeartbeat();
+	public Long millisSinceLastEvent() {
+		return binlogParser.millisSinceLastEvent();
 	}
 
 	/**

--- a/src/main/java/com/google/code/or/OpenReplicator.java
+++ b/src/main/java/com/google/code/or/OpenReplicator.java
@@ -20,6 +20,9 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -73,6 +76,7 @@ public class OpenReplicator {
 	protected int level1BufferSize = 1024 * 1024;
 	protected int level2BufferSize = 8 * 1024 * 1024;
 	protected int socketReceiveBufferSize = 512 * 1024;
+	protected Float heartbeatPeriod = null;
 
 	//
 	protected Transport transport;
@@ -103,6 +107,7 @@ public class OpenReplicator {
 			this.binlogParser = getDefaultBinlogParser();
 
 		setupChecksumState();
+		setupHeartbeatPeriod();
 		dumpBinlog();
 
 		this.binlogParser.setBinlogFileName(this.binlogFileName);
@@ -270,6 +275,33 @@ public class OpenReplicator {
 				throw e;
 		}
 	}
+
+	protected void setupHeartbeatPeriod() throws Exception {
+		if ( this.heartbeatPeriod == null )
+			return;
+
+		BigInteger nanoSeconds = BigDecimal.valueOf(1000000000).multiply(BigDecimal.valueOf(this.heartbeatPeriod)).toBigInteger();
+
+		final Query query = new Query(this.transport);
+		query.getFirst("SET @master_heartbeat_period = " + nanoSeconds);
+	}
+
+	public void setHeartbeatPeriod(float period) {
+		this.heartbeatPeriod = period;
+	}
+
+	public Float getHeartbeatPeriod() {
+		return this.heartbeatPeriod;
+	}
+
+	public long getHeartbeatCount() {
+		return binlogParser.getHeartbeatCount();
+	}
+
+	public Long millisSinceLastHeartbeat() {
+		return binlogParser.millisSinceLastHeartbeat();
+	}
+
 	/**
 	 *
 	 */
@@ -333,7 +365,7 @@ public class OpenReplicator {
 		r.registerEventParser(new DeleteRowsEventV2Parser());
 		r.registerEventParser(new FormatDescriptionEventParser());
 		r.registerEventParser(new GtidEventParser());
-		
+
 		//
 		r.setTransport(this.transport);
 		return r;

--- a/src/main/java/com/google/code/or/binlog/impl/ReplicationBasedBinlogParser.java
+++ b/src/main/java/com/google/code/or/binlog/impl/ReplicationBasedBinlogParser.java
@@ -42,7 +42,7 @@ public class ReplicationBasedBinlogParser extends AbstractBinlogParser {
 	//
 	private static final Logger LOGGER = LoggerFactory.getLogger(ReplicationBasedBinlogParser.class);
 	protected long heartbeatCount = 0;
-	protected long lastHeartbeatMillis = 0;
+	protected Long lastEventMillis = null;
 
 	//
 	protected Transport transport;
@@ -99,20 +99,15 @@ public class ReplicationBasedBinlogParser extends AbstractBinlogParser {
 		}
 	}
 
-	private void processHeartbeat() {
-		this.heartbeatCount++;
-		this.lastHeartbeatMillis = System.currentTimeMillis();
-	}
-
 	public long getHeartbeatCount() {
 		return this.heartbeatCount;
 	}
 
-	public Long millisSinceLastHeartbeat() {
-		if ( this.heartbeatCount == 0 )
+	public Long millisSinceLastEvent() {
+		if ( this.lastEventMillis == null )
 			return null;
 
-		return System.currentTimeMillis() - this.lastHeartbeatMillis;
+		return System.currentTimeMillis() - this.lastEventMillis;
 	}
 
 	/**
@@ -133,7 +128,9 @@ public class ReplicationBasedBinlogParser extends AbstractBinlogParser {
 			boolean isFormatDescriptionEvent = header.getEventType() == MySQLConstants.FORMAT_DESCRIPTION_EVENT;
 
 			if ( header.getEventType() == MySQLConstants.HEARTBEAT_LOG_EVENT )
-				this.processHeartbeat();
+				this.heartbeatCount++;
+
+			this.lastEventMillis = System.currentTimeMillis();
 
 			// Parse the event body
 			if(this.eventFilter != null && !this.eventFilter.accepts(header, context)) {

--- a/src/test/java/com/google/code/or/OpenReplicatorTest.java
+++ b/src/test/java/com/google/code/or/OpenReplicatorTest.java
@@ -87,4 +87,15 @@ public class OpenReplicatorTest {
 
 		TestReplicator(or);
 	}
+
+	@Test
+	public void TestHeartbeatReplicator() throws Exception {
+		OpenReplicator or = getOpenReplicator(fiveSixServer, "master.000001", 4L);
+		or.setHeartbeatPeriod(0.1f);
+		TestReplicator(or);
+
+		assert(or.getHeartbeatCount() > 5);  // depends on timing, really
+		assert(or.millisSinceLastHeartbeat() != null);
+		assert(or.millisSinceLastHeartbeat() > 0);
+	}
 }

--- a/src/test/java/com/google/code/or/OpenReplicatorTest.java
+++ b/src/test/java/com/google/code/or/OpenReplicatorTest.java
@@ -95,7 +95,7 @@ public class OpenReplicatorTest {
 		TestReplicator(or);
 
 		assert(or.getHeartbeatCount() > 5);  // depends on timing, really
-		assert(or.millisSinceLastHeartbeat() != null);
-		assert(or.millisSinceLastHeartbeat() > 0);
+		assert(or.millisSinceLastEvent() != null);
+		assert(or.millisSinceLastEvent() <= 150);
 	}
 }


### PR DESCRIPTION
In production I've seen instances in which a replicas connection is
half-open; some kind of packet indicating that the replica connection
died was lost somewhere along the way, and the replica trundles merrily
along, unaware that the server has written it off entirely.

Implementing heartbeats should help us avoid that situation by noticing
the situation and restarting the replica.

@zendesk/rules 
