### PR TITLE
stop-on-EOF mode for paging through a single log.

### DIFF
--- a/src/main/java/com/google/code/or/OpenReplicator.java
+++ b/src/main/java/com/google/code/or/OpenReplicator.java
@@ -79,6 +79,7 @@ public class OpenReplicator {
 	protected int socketReceiveBufferSize = 512 * 1024;
 	protected Float heartbeatPeriod = null;
 	protected String uuid = UUID.randomUUID().toString();
+	protected boolean stopOnEOF = false;
 
 	//
 	protected Transport transport;
@@ -136,6 +137,8 @@ public class OpenReplicator {
 		this.transport.disconnect();
 
 		this.binlogParser.stop(timeout, unit);
+
+		this.onStop();
 	}
 
 	public void stopQuietly(long timeout, TimeUnit unit) {
@@ -310,6 +313,16 @@ public class OpenReplicator {
 		return binlogParser.millisSinceLastEvent();
 	}
 
+	public boolean isStopOnEOF() {
+		return stopOnEOF;
+	}
+
+	public void setStopOnEOF(boolean stopOnEOF) {
+		this.stopOnEOF = stopOnEOF;
+	}
+
+	public void onStop() { }
+
 	/**
 	 *
 	 */
@@ -317,7 +330,7 @@ public class OpenReplicator {
 		//
 		final ComBinlogDumpPacket command = new ComBinlogDumpPacket();
 		command.setBinlogFlag(0);
-		command.setServerId(this.serverId);
+		command.setServerId(stopOnEOF ? 0 : this.serverId);
 		command.setBinlogPosition(this.binlogPosition);
 		command.setBinlogFileName(StringColumn.valueOf(this.binlogFileName.getBytes(this.encoding)));
 		this.transport.getOutputStream().writePacket(command);
@@ -355,7 +368,7 @@ public class OpenReplicator {
 
 	protected ReplicationBasedBinlogParser getDefaultBinlogParser() throws Exception {
 		//
-		final ReplicationBasedBinlogParser r = new ReplicationBasedBinlogParser();
+		final ReplicationBasedBinlogParser r = new ReplicationBasedBinlogParser(this.stopOnEOF);
 		r.registerEventParser(new StopEventParser());
 		r.registerEventParser(new RotateEventParser());
 		r.registerEventParser(new IntvarEventParser());

--- a/src/main/java/com/google/code/or/OpenReplicator.java
+++ b/src/main/java/com/google/code/or/OpenReplicator.java
@@ -327,7 +327,7 @@ public class OpenReplicator {
 	 *
 	 */
 	protected void dumpBinlog() throws Exception {
-		//
+		LOGGER.info(String.format("starting replication at %s:%d", this.binlogFileName, this.binlogPosition));
 		final ComBinlogDumpPacket command = new ComBinlogDumpPacket();
 		command.setBinlogFlag(0);
 		command.setServerId(stopOnEOF ? 0 : this.serverId);

--- a/src/main/java/com/google/code/or/io/util/ActiveBufferedInputStream.java
+++ b/src/main/java/com/google/code/or/io/util/ActiveBufferedInputStream.java
@@ -154,7 +154,7 @@ public final class ActiveBufferedInputStream extends InputStream implements Runn
         	while (this.ringBuffer.isEmpty()) {
         		if(this.exception != null) throw this.exception;
             	this.bufferNotEmpty.awaitUninterruptibly();
-            	if(this.closed.get()) throw new EOFException();
+            	if(this.closed.get() && this.ringBuffer.isEmpty()) throw new EOFException();
             }
 
         	//
@@ -174,7 +174,7 @@ public final class ActiveBufferedInputStream extends InputStream implements Runn
         	while (this.ringBuffer.isEmpty()) {
         		if(this.exception != null) throw this.exception;
             	this.bufferNotEmpty.awaitUninterruptibly();
-            	if(this.closed.get()) throw new EOFException();
+            	if(this.closed.get() && this.ringBuffer.isEmpty()) throw new EOFException();
             }
 
             //

--- a/src/main/java/com/google/code/or/net/impl/AuthenticatorImpl.java
+++ b/src/main/java/com/google/code/or/net/impl/AuthenticatorImpl.java
@@ -60,7 +60,7 @@ public class AuthenticatorImpl implements Transport.Authenticator {
 	public void login(Transport transport) throws IOException {
 		//
 		final TransportContext ctx = transport.getContext();
-		LOGGER.info("start to login, user: {}, host: {}, port: {}", new Object[]{this.user, ctx.getServerHost(), ctx.getServerPort()});
+		LOGGER.debug("start to login, user: {}, host: {}, port: {}", new Object[]{this.user, ctx.getServerHost(), ctx.getServerPort()});
 
 		//
 		final XSerializer s = new XSerializer(64);
@@ -85,16 +85,16 @@ public class AuthenticatorImpl implements Transport.Authenticator {
 		final Packet response = transport.getInputStream().readPacket();
 		if(response.getPacketBody()[0] == ErrorPacket.PACKET_MARKER) {
 			final ErrorPacket error = ErrorPacket.valueOf(response);
-			LOGGER.info("login failed, user: {}, error: {}", this.user, error);
+			LOGGER.error("login failed, user: {}, error: {}", this.user, error);
 			throw new TransportException(error);
 		} else if(response.getPacketBody()[0] == EOFPacket.PACKET_MARKER) {
-			LOGGER.info("Old style password authentication is not supported, upgrade user {} to a new style password or specify a different user", this.user);
+			LOGGER.error("Old style password authentication is not supported, upgrade user {} to a new style password or specify a different user", this.user);
 			throw new RuntimeException("Old style password authentication not supported");
 		} else if(response.getPacketBody()[0] == OKPacket.PACKET_MARKER) {
 			final OKPacket ok = OKPacket.valueOf(response);
-			LOGGER.info("login successfully, user: {}, detail: {}", this.user, ok);
+			LOGGER.debug("login successfully, user: {}, detail: {}", this.user, ok);
 		} else {
-			LOGGER.warn("login failed, unknown packet: ", response);
+			LOGGER.error("login failed, unknown packet: ", response);
 			throw new RuntimeException("assertion failed, invalid packet: " + response);
 		}
 	}

--- a/src/main/java/com/google/code/or/net/impl/TransportImpl.java
+++ b/src/main/java/com/google/code/or/net/impl/TransportImpl.java
@@ -64,7 +64,7 @@ public class TransportImpl extends AbstractTransport {
 
 		//
 		if(isVerbose() && LOGGER.isInfoEnabled()) {
-			LOGGER.info("connecting to host: {}, port: {}", host, port);
+			LOGGER.debug("connecting to host: {}, port: {}", host, port);
 		}
 
 		//
@@ -80,7 +80,7 @@ public class TransportImpl extends AbstractTransport {
 		final Packet packet = this.is.readPacket();
 		if(packet.getPacketBody()[0] == ErrorPacket.PACKET_MARKER) {
 			final ErrorPacket error = ErrorPacket.valueOf(packet);
-			LOGGER.info("failed to connect to host: {}, port: {}, error", new Object[]{host, port, error});
+			LOGGER.warn("failed to connect to host: {}, port: {}, error", new Object[]{host, port, error});
 			throw new TransportException(error);
 		} else {
 			//
@@ -97,7 +97,7 @@ public class TransportImpl extends AbstractTransport {
 
 			//
 			if(isVerbose() && LOGGER.isInfoEnabled()) {
-				LOGGER.info("connected to host: {}, port: {}, context: {}", new Object[]{host, port, this.context});
+				LOGGER.debug("connected to host: {}, port: {}, context: {}", new Object[]{host, port, this.context});
 			}
 		}
 
@@ -118,7 +118,7 @@ public class TransportImpl extends AbstractTransport {
 
 		//
 		if(isVerbose() && LOGGER.isInfoEnabled()) {
-			LOGGER.info("disconnected from {}:{}", this.context.getServerHost(), this.context.getServerPort());
+			LOGGER.debug("disconnected from {}:{}", this.context.getServerHost(), this.context.getServerPort());
 		}
 	}
 

--- a/src/test/java/com/google/code/or/OnetimeServer.java
+++ b/src/test/java/com/google/code/or/OnetimeServer.java
@@ -35,8 +35,15 @@ public class OnetimeServer {
 	public void boot() throws IOException, InterruptedException {
 		final String dir = System.getProperty("user.dir");
 
-		ProcessBuilder pb = new ProcessBuilder(dir + "/src/test/onetimeserver", "--mysql-version=" + mysqlVersion,
-				"--log-bin=master", "--binlog_format=row", "--innodb_flush_log_at_trx_commit=1", "--server_id=" + SERVER_ID);
+		ProcessBuilder pb = new ProcessBuilder(
+			dir + "/src/test/onetimeserver",
+			"--mysql-version=" + mysqlVersion,
+			"--log-bin=master",
+			"--binlog_format=row",
+			"--innodb_flush_log_at_trx_commit=1",
+			"--server_id=" + SERVER_ID,
+			"--sync_binlog=1"
+		);
 		Process p = pb.start();
 		BufferedReader reader = new BufferedReader(new InputStreamReader(p.getInputStream()));
 

--- a/src/test/java/com/google/code/or/OpenReplicatorTest.java
+++ b/src/test/java/com/google/code/or/OpenReplicatorTest.java
@@ -1,19 +1,31 @@
 package com.google.code.or;
 
-import java.io.BufferedReader;
-import java.io.InputStreamReader;
-import java.util.concurrent.TimeUnit;
+import java.sql.Time;
+import java.util.Date;
+import java.sql.PreparedStatement;
+import java.sql.Timestamp;
+import java.util.List;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.atomic.AtomicReference;
 
 import com.google.code.or.binlog.*;
 import com.google.code.or.binlog.impl.ReplicationBasedBinlogParser;
 import com.google.code.or.binlog.impl.event.WriteRowsEventV2;
+import com.google.code.or.common.glossary.Column;
+import com.google.code.or.common.glossary.Row;
+import com.google.code.or.common.glossary.column.Datetime2Column;
+import com.google.code.or.common.glossary.column.Time2Column;
+import com.google.code.or.common.glossary.column.Timestamp2Column;
 import com.google.code.or.common.util.MySQLConstants;
 import com.google.code.or.net.Transport;
-import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
 
 public class OpenReplicatorTest {
 	private static final Logger LOGGER = LoggerFactory.getLogger(OpenReplicatorTest.class);
@@ -30,8 +42,7 @@ public class OpenReplicatorTest {
 		fiveSixServer.execute("create table foo.bar ( id int(10) primary key )");
 	}
 
-	@Before
-	public void createData() throws Exception {
+	private void createData() throws Exception {
 		fiveSixServer.execute("RESET MASTER");
 		fiveSixServer.execute("TRUNCATE TABLE foo.bar");
 
@@ -68,14 +79,30 @@ public class OpenReplicatorTest {
 		return eventCount;
 	}
 
+	private WriteRowsEventV2 getFirstInsert(OpenReplicator or) throws Exception {
+		final AtomicReference<WriteRowsEventV2> ref = new AtomicReference<WriteRowsEventV2>();
+		or.setBinlogEventListener(new BinlogEventListener() {
+			public void onEvents(BinlogEventV4 event) {
+				if (event instanceof WriteRowsEventV2) {
+					ref.set((WriteRowsEventV2) event);
+				}
+			}
+		});
+		or.start();
+		Thread.sleep(2000);
+		return ref.get();
+	}
+
 	@Test
 	public void TestNormalReplicator() throws Exception {
+		createData();
 		int count = TestReplicator(getOpenReplicator(fiveSixServer, "master.000001", 4L));
 		assert(count == 2);
 	}
 
 	@Test
 	public void TestParserWithoutFormatDescriptionListener() throws Exception {
+		createData();
 		OpenReplicator or = getOpenReplicator(fiveSixServer, "master.000001", 120L);
 
 		Transport transport = or.getDefaultTransport();
@@ -99,6 +126,7 @@ public class OpenReplicatorTest {
 
 	@Test
 	public void TestHeartbeatReplicator() throws Exception {
+		createData();
 		OpenReplicator or = getOpenReplicator(fiveSixServer, "master.000001", 4L);
 		or.setHeartbeatPeriod(0.1f);
 		TestReplicator(or);
@@ -111,6 +139,7 @@ public class OpenReplicatorTest {
 
 	@Test
 	public void testStopOnEof() throws Exception {
+		createData();
 		fiveSixServer.execute("FLUSH LOGS");
 		fiveSixServer.execute("insert into foo.bar set id = 3");
 
@@ -118,5 +147,85 @@ public class OpenReplicatorTest {
 		or.setStopOnEOF(true);
 		TestReplicator(or);
 		assert !or.isRunning();
+	}
+
+	private void testPrecision(String type, String table, String... times) throws Exception {
+		fiveSixServer.execute("RESET MASTER");
+		fiveSixServer.execute(
+			String.format(
+				"create table foo.%s ( t1 %s(1), t2 %s(2), t3 %s(3), t4 %s(4), t5 %s(5), t6 %s(6))",
+				table,
+				type, type, type, type, type, type
+			)
+		);
+		String insertSQL = String.format("insert into foo.%s values(?, ?, ?, ?, ?, ?)", table);
+		PreparedStatement s	= fiveSixServer.getConnection().prepareStatement(insertSQL);
+
+		for ( int i = 0; i < 6; i++ ) {
+			s.setString(i + 1, times[i]);
+		}
+
+		s.execute();
+
+		OpenReplicator or = getOpenReplicator(fiveSixServer, "master.000001", 4L);
+		WriteRowsEventV2 event = getFirstInsert(or);
+		Row row = event.getRows().get(0);
+		assertThat(row, is(not(nullValue())));
+		List<Column> columns = row.getColumns();
+		for ( int i = 0; i < 6; i++ ) {
+			Column c = columns.get(i);
+			if ( c instanceof Timestamp2Column ) {
+				assertEquals(times[i], c.toString());
+	 		} else if ( c instanceof Datetime2Column ) {
+	 			Timestamp ts = Timestamp.valueOf(times[i]);
+				assertEquals(ts.getTime(), ((Date) c.getValue()).getTime());
+			} else if ( c instanceof Time2Column ) {
+				Timestamp t = Timestamp.valueOf("1970-01-01 " + times[i]);
+				Time t2 = (Time) c.getValue();
+				assertEquals(t.getTime(), t2.getTime());
+			}
+		}
+	}
+
+	@Test
+	public void testTimestampPrecision() throws Exception {
+		testPrecision(
+			"timestamp",
+			"ts",
+			"2001-01-01 00:00:00.9",
+			"2001-01-01 00:00:00.99",
+			"2001-01-01 00:00:00.999",
+			"2001-01-01 00:00:00.9999",
+			"2001-01-01 00:00:00.99999",
+			"2001-01-01 00:00:00.999999"
+		);
+	}
+
+	@Test
+	public void testDatetimePrecision() throws Exception {
+		testPrecision(
+			"datetime",
+			"dt",
+			"2001-01-01 00:00:00.9",
+			"2001-01-01 00:00:00.99",
+			"2001-01-01 00:00:00.999",
+			"2001-01-01 00:00:00.9999",
+			"2001-01-01 00:00:00.99999",
+			"2001-01-01 00:00:00.999999"
+		);
+	}
+
+	@Test
+	public void testTimePrecision() throws Exception {
+		testPrecision(
+			"time",
+			"tm",
+			"00:00:00.9",
+			"00:00:00.99",
+			"00:00:00.999",
+			"00:00:00.9999",
+			"00:00:00.99999",
+			"00:00:00.999999"
+		);
 	}
 }


### PR DESCRIPTION
It's an undocumented (or barely documented) feature of mysql replication that if you set the server_id to 0, mysql will end an EOF packet when it reaches the end of the binlogs.  Useful for copying single logs from the server.

@zendesk/rules cc @gabetax (bcs this could be useful in our binlog_service)
