### PR TITLE
Lazy status variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@ Open Replicator is a high performance MySQL binlog parser written in Java. It un
 
 ### releases
 
+1.6.0
+
+    release: 2016-09-27
+    better microsecond timestamp precision, thanks Michel Pigassou
+    (all datetime2 classes now expose getTimestampValue(), which preserves all the time precision)
+
 1.5.1
 
     release: 2016-09-21

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.zendesk</groupId>
   <artifactId>open-replicator</artifactId>
-  <version>1.5.1</version>
+  <version>1.6.0</version>
   <packaging>jar</packaging>
 
   <name>open-replicator</name>

--- a/src/main/java/com/google/code/or/binlog/impl/event/QueryEvent.java
+++ b/src/main/java/com/google/code/or/binlog/impl/event/QueryEvent.java
@@ -154,7 +154,7 @@ public final class QueryEvent extends AbstractBinlogEventV4 {
 		this.sql = sql;
 	}
 
-	public void setStatusVariableBytes(byte[] bytes) {
+	public synchronized void setStatusVariableBytes(byte[] bytes) {
 		this.statusVariablesParsed = false;
 		this.statusVariableBytes = bytes;
 	}

--- a/src/main/java/com/google/code/or/binlog/impl/parser/QueryEventParser.java
+++ b/src/main/java/com/google/code/or/binlog/impl/parser/QueryEventParser.java
@@ -71,7 +71,7 @@ public class QueryEventParser extends AbstractBinlogEventParser {
 		event.setDatabaseNameLength(is.readInt(1));
 		event.setErrorCode(is.readInt(2));
 		event.setStatusVariablesLength(is.readInt(2));
-		event.setStatusVariables(parseStatusVariables(is.readBytes(event.getStatusVariablesLength())));
+		event.setStatusVariableBytes(is.readBytes(event.getStatusVariablesLength()));
 		event.setDatabaseName(is.readNullTerminatedString());
 		event.setSql(is.readFixedLengthString(is.available()));
 		context.getEventListener().onEvents(event);
@@ -80,7 +80,7 @@ public class QueryEventParser extends AbstractBinlogEventParser {
 	/**
 	 *
 	 */
-	protected List<StatusVariable> parseStatusVariables(byte[] data)
+	public static List<StatusVariable> parseStatusVariables(byte[] data)
 	throws IOException {
 		final List<StatusVariable> r = new ArrayList<StatusVariable>();
 		final XDeserializer d = new XDeserializer(data);


### PR DESCRIPTION
In local benchmarks, parsing the status variables of a query-event took up a huge majority of the processing time.  I think it might be synthetic, but since status variables are a not-quite-that-used feature I think it's fine to defer the parsing. 

@zendesk/rules 
